### PR TITLE
Optimize Promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ exports.getRepoLanguages = (visibility, token) => {
     return getUserRepos(visibility, token).then((repos) => {
         var urls = _.map(repos, 'languages_url');
         // Push a function for each URL to get the languages byte count, and process them asynchronously
-        var promises = _.map(urls, _.curry(createAPIRequestPromiseFunc)(token, null));
+        var promises = _.map(urls, _.curry(createAPIRequestPromise)(token, null));
         return Promise.all(promises);
     }).then(responses => {
         var results = _.map(responses, 'body');
@@ -90,7 +90,7 @@ exports.getCommitLanguages = (visibility, token) => {
                     var urls = _.filter(_.map(commits, 'url'), (c) => {
                         return c !== undefined;
                     });
-                    var promises = _.map(urls, _.curry(createAPIRequestPromiseFunc)(token, null));
+                    var promises = _.map(urls, _.curry(createAPIRequestPromise)(token, null));
                     resolve(Promise.all(promises));
                 });
             }).then(responses => {
@@ -194,7 +194,7 @@ function getRepoCommits(username, token, repoUrl) {
                 var start = Number(link.next.page);
                 var end = Number(link.last.page);
                 for (var page = start; page <= end; page++) {
-                    funcs.push(_.curry(createAPIRequestFunc)(token, page, repoUrl))
+                    funcs.push(_.curry(createAPIRequestFunc)(token, page, repoUrl));
                 }
                 async.parallelPlus(funcs, (err, results) => { // eslint-disable-line
                     _.each(results, (result) => {
@@ -217,9 +217,9 @@ function getRepoCommits(username, token, repoUrl) {
  * @param  {String} token   Github personal access token
  * @param  {Integer} page   Used for pagination, can be undefined
  * @param  {String} url     Github API URL
- * @return {Function}       Function to be passed into Async call with callback
+ * @return {Promise}        Promise to be passed into Promise.all()
  */
-function createAPIRequestPromiseFunc(token, page, url) {
+function createAPIRequestPromise(token, page, url) {
     // Form options for API request
     var options = _.defaults({
         uri: url,

--- a/index.js
+++ b/index.js
@@ -55,25 +55,26 @@ exports.getRepoLanguages = (visibility, token) => {
  *                              Rejects if parameters are invalid, or error occurs with API request
  */
 exports.getCommitLanguages = (visibility, token) => {
-    return new Promise((resolve, reject) => {
-        getUserRepos(visibility, token).then((repos) => {
-            // Get Github username from access token
-            var options = _.defaults({
-                uri: API_BASE_URL + '/user',
-                qs: {
-                    access_token: token, // eslint-disable-line
-                },
-                resolveWithFullResponse: false
-            }, baseOpts);
+    return getUserRepos(visibility, token).then((repos) => {
+        // Get Github username from access token
+        var options = _.defaults({
+            uri: API_BASE_URL + '/user',
+            qs: {
+                access_token: token, // eslint-disable-line
+            },
+            resolveWithFullResponse: false
+        }, baseOpts);
 
-            // Perform API request and handle result appropriately
-            request(options).then((user) => {
-                // Get Repo commit URLs
-                var urls = _.map(repos, (repo) => {
-                    return repo.url + '/commits'
-                });
+        // Perform API request and handle result appropriately
+        return request(options).then((user) => {
+            // Get Repo commit URLs
+            var urls = _.map(repos, (repo) => {
+                return repo.url + '/commits'
+            });
 
-                var funcs = _.map(urls, _.curry(getRepoCommits)(user.login, token));
+            var funcs = _.map(urls, _.curry(getRepoCommits)(user.login, token));
+            return new Promise((resolve, reject) => {
+
                 async.parallelPlus(funcs, (err, results) => { // eslint-disable-line
                     // Filter out undefined results
                     var commitArrays = _.filter(results, (result) => {
@@ -114,11 +115,7 @@ exports.getCommitLanguages = (visibility, token) => {
                         resolve(totals);
                     });
                 });
-            }).catch((err) => {
-                reject(err);
             });
-        }).catch((err) => {
-            reject(err);
         });
     });
 };


### PR DESCRIPTION
First off, sorry this PR is so big. The changes I made, given my testing, keep the same functionality but optimize the use of Promises. The logic is rooted in several truths:

1. Reduce the # of
```js
  }).catch(err => {
    reject(err);
  })
```

None of these are necessary, because a that rejects, is going to do so up the chain until the next error handler (in this case `.catch`). The `catch` handler in this case doesn't do anything special but re-"throw" this rejection up the chain. Remember, you should always be able to write Promise-driven async code similar to its synchronous counterparts. Many `.catch(e => { reject(e) })` handlers isn't doing anything. It is the same as this synchronous code:

```js
try {
    try { callErrorThrowingFunction(); } catch (e) {
        throw e;
    }
} catch (e) {
  console.error('ehh, sorry boss');
}
```

In the above case, the inner error-handler is worthless, as it isn't doing anything special but re-throwing. Now if we were to modify the error (maybe to obscure private data returned from some "private" function we own) it would be worth having that inner `catch` since we're transforming the error. If we're not doing anything, not including it is totally fine because the error will be thrown to up to the nearest catch handler, and no code will be run until the error is handled. In other words, the only thing that matters is the last error handler, and of course ensuring it does something more than what would happen without it.

The same goes for Promises. If you want you can test this out in the DevTools:

```js
x = new Promise((resolve, reject) => {
  reject(4);
})
.then(_=>{/*some transform here?*/})
.then(_=>{/*some transform here?*/})
.then(_=>{/*some transform here?*/})
.catch(console.error);
```

...where all fulfillment handlers are skipped until the next `catch`. Any `catch` in between that just re-throws the error is redundant.

2. No need to always wrap in `return new Promise(...` and generate nesting 

Consider this contrived example, where in order to get a repository from the server, we must first get the user information.

```js
// Returns a promise that resolves to repo information
function getRepo() {
    return new Promise((resolve, reject) => {
        getUser().then(userInfo => {
            makeRepositoryRequestWithUserInfo(userInfo).then(repoInfo => {
                resolve(repoInfo);
            });
        });
    });
}

// Returns a promise that resolve to user information
function getUser();...
```

In this example we're subject to the same nesting that callbacks give us :(. We can do better by using the Promise returned by `getUser` instead of just wrapping it up. Promises are `lit` because they allow us to reduce nesting by using `.then(...`. Consider code that is functionally equivalent:

```js
function getRepo() {
    return getUser()
        .then(userInfo => {
            return makeRepositoryRequestWithUserInfo(userInfo);
        })
        .then(repoInfo => {
            // Maybe do some trimming or pruning of repoInfo object?
            return repoInfo;
        })
        .catch(err => {
            throw {'reason': err.publicSafeReason}; // don't expose possible sensitive err data to caller
        });
}
```

The user of this function will call `getRepo()` and the promise returned will either resolve with repository information, or reject with a public-safe error object that we've made ready for them to consume. Note if we didn't `throw` in our `catch` handler, and instead returned some default repository data, or even `undefined` then technically a call to `getRepo()` would never result in a rejected promise (sometimes this is ideal).

I reduced use of `async.parallel` too. I deemed calls to `async.parallel` as replaceable with `Promise.all([p1, p2, p3])`. The reasoning is because when using Promises, I try and use promises wherever I can. When using `async.parallel` you're getting the same functionality as `Promise.all` but now we have to mix promises with callbacks (meaning we have to wrap callback-driven routines (async.parallel) in a `new Promise(...`). I replaced all uses (except for one) of `async.parallel` with `Promise.map()` so that we could use Promises more often. This also gives us a perf optimization because the Promises are implemented natively in Node (try `Promise.all.toString()`) so it's gonna be faster than something a JS library can offer you.

I said I replaced all instances of async.parallel *except one*. This is because you're using a custom `async.parallelPlus`, for what I can tell, to simulate functionality that `async.parallel` would have if it didn't give up on the first received error? If this is correct:

1. Would [`async.reflectAll`](https://caolan.github.io/async/docs.html#reflectAll) be a viable replacement?
2. Even with async.reflectAll, we're still still limited to callbacks though, so consider:

`Promise.all([])` is limited in that it behaves too much like `async.parallel`, in that it rejects on the first rejected promise in the promise array you give it. What we need is a `Promise.all` that never gives up, namely a `Promise.all` that gives us an array of both resolves and rejections. My proposal is that we remove the `async` dependency and replace it with `bluebird` that will act as the provider for `Promise.map` and [`Promise.reflect`](http://stackoverflow.com/a/25817815/3947332) which will give us this functionality. We'll use native promises for everything else, but bluebird promises for calls to `parallelPlus`. This will also allow us to get rid of `createAPIRequestFunc` and solely use `createAPIRequestPromise`.

With all that being said, if I misunderstood your intent with `parallelPlus`, nvm.